### PR TITLE
Fixed invalid URL

### DIFF
--- a/DocuPort_PSG/DocuPort_PSG_CLI.py
+++ b/DocuPort_PSG/DocuPort_PSG_CLI.py
@@ -114,7 +114,7 @@ def keyboardMouse_Cap() -> None:
 
 def menus() -> None:
     load('Opening \"Menus\" Doc Section', 'Done!')
-    url = r'https://pysimplegui.readthedocs.io/en/latest/#menud'
+    url = r'https://pysimplegui.readthedocs.io/en/latest/#menus'
     openURL(url, new=2, autoraise=True)
 
 


### PR DESCRIPTION
- Fixed typo in URL for opening the "Menus" PSG online docs section in CLI app.

Signed-off-by: schlopp96 <71921821+schlopp96@users.noreply.github.com>